### PR TITLE
chore(socket.io): Remove port numbers from client-side Socket.IO connection URLs

### DIFF
--- a/frontend/src/components/dashboard/dashboard2024/AdoptionApplicationBypassCode.tsx
+++ b/frontend/src/components/dashboard/dashboard2024/AdoptionApplicationBypassCode.tsx
@@ -55,7 +55,7 @@ const CodeCopied = styled.div<{ anim: string }>`
 `;
 
 // const socket = io('http://localhost:5000')
-const socket = io('https://www.littlepawsdr.org:5000');
+const socket = io('https://www.littlepawsdr.org');
 
 const AdoptionApplicationBypassCode = () => {
   const dispatch = useAppDispatch()

--- a/frontend/src/routes/Admin/Campaigns/index.tsx
+++ b/frontend/src/routes/Admin/Campaigns/index.tsx
@@ -172,7 +172,7 @@ const Sidebar = ({ sidebarLinkArr }: any) => {
 
 
 // const socket = io('http://localhost:5000');
-const socket = io('https://www.littlepawsdr.org:5000');
+const socket = io('https://www.littlepawsdr.org');
 
 const CampaignLayout = ({ navbar, children }: any) => {
   const { id } = useParams();

--- a/frontend/src/routes/Admin/Dashboard.tsx
+++ b/frontend/src/routes/Admin/Dashboard.tsx
@@ -7,7 +7,7 @@ import { io } from 'socket.io-client';
 import { useSelector } from 'react-redux';
 
 // const socket = io('http://localhost:5000')
-const socket = io('https://www.littlepawsdr.org:5000');
+const socket = io('https://www.littlepawsdr.org');
 
 const Dashboard = () => {
   const dispatch = useAppDispatch()

--- a/frontend/src/routes/Campaign/index.tsx
+++ b/frontend/src/routes/Campaign/index.tsx
@@ -22,7 +22,7 @@ interface CampaignLayoutProps {
 
 
 // const socket = io('http://localhost:5000');
-const socket = io('https://www.littlepawsdr.org:5000');
+const socket = io('https://www.littlepawsdr.org');
 
 const CampaignLayout: FC<CampaignLayoutProps> = ({ navbar, children }) => {
   const params = useParams();


### PR DESCRIPTION
This pull request attempts to remove the socket io warning "https://www.littlepawsdr.org:5000/socket.io/?EIO=4&transport=polling&t=OzEZ6p- net::ERR_TIMED_OUT"